### PR TITLE
Fix update payment session call bad request issue

### DIFF
--- a/VillageWalletSDKOAIClient.podspec
+++ b/VillageWalletSDKOAIClient.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name = "VillageWalletSDKOAIClient"
-  spec.version = "4.0.1"
+  spec.version = "4.0.2"
   spec.summary = "Open API implementation of Village API Repositories"
 
   # This description is used to generate tags and improve search results.

--- a/VillageWalletSDKOAIClient/Api/OpenApiCustomerPaymentSessionsRepository.swift
+++ b/VillageWalletSDKOAIClient/Api/OpenApiCustomerPaymentSessionsRepository.swift
@@ -60,6 +60,7 @@ public class OpenApiCustomerPaymentSessionsRepository: OpenApiClientFactory, Cus
 		let body = OAIUpdatePaymentSessionRequest()
 		body.data = OAIInstoreCustomerPaymentSessionPaymentSessionIdData()
 		body.data.customerInfo = toDynamicPayload(payload: session.customerInfo)
+		body.meta = [:]
 
 		api.customerUpdatePaymentSession(
 			withXApiKey: getDefaultHeader(client: api.apiClient, name: X_API_KEY),

--- a/VillageWalletSDKOAIClientTests/Podfile.lock
+++ b/VillageWalletSDKOAIClientTests/Podfile.lock
@@ -18,7 +18,7 @@ PODS:
   - JSONModel (1.8.0)
   - SwiftHamcrest (2.2.2)
   - VillageWalletSDK (4.0.1)
-  - VillageWalletSDKOAIClient (4.0.1):
+  - VillageWalletSDKOAIClient (4.0.2):
     - AFNetworking (~> 4)
     - ISO8601 (~> 0.6)
     - JSONModel (~> 1.2)
@@ -54,7 +54,7 @@ SPEC CHECKSUMS:
   JSONModel: 02ab723958366a3fd27da57ea2af2113658762e9
   SwiftHamcrest: 940c3dae2a31f92da433f5a0b13d42103247051b
   VillageWalletSDK: f420326cf908809ea12695a7cc2d9c4ab789e396
-  VillageWalletSDKOAIClient: 06b247ae3f6f5676b623bd6f5a1856993e03d854
+  VillageWalletSDKOAIClient: 5c5e69b7999f88beab8b1d8166ad918fac5f6217
 
 PODFILE CHECKSUM: 25dfe94b34c6b971674079431bb77776275a7f79
 


### PR DESCRIPTION
### Description
Fix update payment session bad request issue
Add the required request parameter `meta` to the POST `/instore/customer/payment/session/{paymentSessionId}` call as per the api spec 1.0.3.

Fixes #4 